### PR TITLE
style(tailwind): add custom font sizes from style guide

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,18 +1,64 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
-    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
-    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
-    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
+    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
+    fontSize: {
+      xs: ["0.75rem", "1.25rem"],
+      sm: ["0.875rem", "1.5rem"],
+      base: ["1rem", "1.5rem"],
+      lg: ["1.5rem", "2rem"],
+      xl: [
+        "2rem",
+        {
+          lineHeight: "2.5rem",
+          letterSpacing: "-0.02em",
+          fontWeight: "700",
+        },
+      ],
+      "2xl": [
+        "2.5rem",
+        {
+          lineHeight: "3rem",
+          letterSpacing: "-0.025em",
+          fontWeight: "700",
+        },
+      ],
+      "3xl": [
+        "3rem",
+        {
+          lineHeight: "3.5rem",
+          letterSpacing: "-0.06em",
+          fontWeight: "700",
+        },
+      ],
+      "4xl": [
+        "4rem",
+        {
+          lineHeight: "4rem",
+          letterSpacing: "-0.08em",
+          fontWeight: "700",
+        },
+      ],
+      "5xl": [
+        "6rem",
+        {
+          lineHeight: "6rem",
+          letterSpacing: "-0.12em",
+          fontWeight: "700",
+        },
+      ],
+    },
     extend: {
       backgroundImage: {
-        'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
-        'gradient-conic':
-          'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
+        "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
+        "gradient-conic":
+          "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
       },
     },
   },
   plugins: [],
-}
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,64 +1,64 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
-    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
     fontSize: {
-      xs: ["0.75rem", "1.25rem"],
-      sm: ["0.875rem", "1.5rem"],
-      base: ["1rem", "1.5rem"],
-      lg: ["1.5rem", "2rem"],
+      xs: ['0.75rem', '1.25rem'],
+      sm: ['0.875rem', '1.5rem'],
+      base: ['1rem', '1.5rem'],
+      lg: ['1.5rem', '2rem'],
       xl: [
-        "2rem",
+        '2rem',
         {
-          lineHeight: "2.5rem",
-          letterSpacing: "-0.02em",
-          fontWeight: "700",
+          lineHeight: '2.5rem',
+          letterSpacing: '-0.02em',
+          fontWeight: '700',
         },
       ],
-      "2xl": [
-        "2.5rem",
+      '2xl': [
+        '2.5rem',
         {
-          lineHeight: "3rem",
-          letterSpacing: "-0.025em",
-          fontWeight: "700",
+          lineHeight: '3rem',
+          letterSpacing: '-0.025em',
+          fontWeight: '700',
         },
       ],
-      "3xl": [
-        "3rem",
+      '3xl': [
+        '3rem',
         {
-          lineHeight: "3.5rem",
-          letterSpacing: "-0.06em",
-          fontWeight: "700",
+          lineHeight: '3.5rem',
+          letterSpacing: '-0.06em',
+          fontWeight: '700',
         },
       ],
-      "4xl": [
-        "4rem",
+      '4xl': [
+        '4rem',
         {
-          lineHeight: "4rem",
-          letterSpacing: "-0.08em",
-          fontWeight: "700",
+          lineHeight: '4rem',
+          letterSpacing: '-0.08em',
+          fontWeight: '700',
         },
       ],
-      "5xl": [
-        "6rem",
+      '5xl': [
+        '6rem',
         {
-          lineHeight: "6rem",
-          letterSpacing: "-0.12em",
-          fontWeight: "700",
+          lineHeight: '6rem',
+          letterSpacing: '-0.12em',
+          fontWeight: '700',
         },
       ],
     },
     extend: {
       backgroundImage: {
-        "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
-        "gradient-conic":
-          "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
+        'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
+        'gradient-conic':
+          'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
       },
     },
   },
   plugins: [],
-};
+}


### PR DESCRIPTION
# 🚀 What's changed?

- Add custom font sizes to the tailwind config, which were taken from the style guide.

# 🌻 Resolves

- [x] Resolves [#13](https://github.com/BursaBilisimToplulugu/maps/issues/13)

# 🎨 Design

- [x] [Figma design link](https://www.figma.com/file/wUVD6IfnxiYYtah7PB8Sai/noName?type=design&node-id=110-15503&mode=dev)

# 📝 Notes

- There are some gaps between font sizes in style guide. For example, there isn't any font sizes between 16px and 24px, 24px and 32px, 48px and 64px, etc. I think, we should add them if we'll use font sizes such as 18px, 20px, 28px, 56px etc.